### PR TITLE
added gitignore, added example, export type signature of new id type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# OCAML artifacts
+_build/
+_opam/

--- a/emblem.opam
+++ b/emblem.opam
@@ -9,13 +9,11 @@ authors: ["Adam Ringwood"]
 license: "MIT"
 homepage: "https://github.com/unrealakama/emblem"
 bug-reports: "https://github.com/unrealakama/emblem/issues"
-name: "emblem"
 depends: [
   "dune" {>= "2.7" & > "2.7"}
   "zarith" {> "1.9"}
   "rresult" {> "0.6"}
   "fmt" {> "0.8.7"}
-  "yojson"
   "odoc" {with-doc}
 ]
 build: [

--- a/example/dune
+++ b/example/dune
@@ -1,0 +1,3 @@
+(executable
+ (name example)
+ (libraries emblem))

--- a/example/example.ml
+++ b/example/example.ml
@@ -1,0 +1,29 @@
+module NewId (M : Emblem.Ids.IdSig) = struct
+  let to_big (e: M.t) =
+    M.to_yojson e
+end
+
+module type Tag = sig
+  val tag : int
+end
+
+module Id (M : Tag) = struct
+  include Emblem.Ids.Id (struct
+    let tag = Z.of_int M.tag
+    and tag_len = 3
+  end)
+
+  let tag = M.tag
+end
+
+module NewerId = Id(struct
+  let tag = 1
+end)
+
+module WowNewerId = NewId(NewerId)
+
+let () =
+   let x = NewerId.gen() in
+   let (_: Yojson.Safe.t) = WowNewerId.to_big x  in
+   ()
+

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
-  (name emblem)
-  (public_name emblem)
-  (libraries rresult fmt zarith yojson))
+ (name emblem)
+ (public_name emblem)
+ (libraries rresult fmt zarith yojson unix))

--- a/src/ids.ml
+++ b/src/ids.ml
@@ -5,7 +5,7 @@ module type IdBase = sig
   val tag : Z.t
 end
 
-module Id (B : IdBase) : sig
+module type IdSig = sig
   type t = private Z.t
   val gen : unit -> t
   val get_time : t -> float
@@ -23,7 +23,9 @@ module Id (B : IdBase) : sig
   val eq : t -> t -> bool
   val compare : t -> t -> int
   val pp : Format.formatter -> t -> unit
-end = struct
+end
+
+module Id (B : IdBase) : IdSig = struct
   type t = Z.t
   let random_len = (20 - B.tag_len) * 4
   let tag_len = B.tag_len * 4


### PR DESCRIPTION
I moved the signature for the output of the functor outside of the functor declaration so the type can be used by external libraries.

Also added a gitignore, and rane `dune build @fmt`

